### PR TITLE
Enhance saved views functionality

### DIFF
--- a/apps/api/bruno/indexes/views/create.bru
+++ b/apps/api/bruno/indexes/views/create.bru
@@ -13,12 +13,12 @@ post {
 body:json {
   {
     "name": "Errors last 24h",
-    "description": "Quick triage filter",
     "query": "level:error",
     "filters": [
       { "field": "service", "value": "api", "exclude": false }
     ],
     "sortDirection": "desc",
-    "columns": ["timestamp", "message"]
+    "columns": ["timestamp", "message"],
+    "timeRange": { "type": "relative", "preset": "24h" }
   }
 }

--- a/apps/api/bruno/indexes/views/patch.bru
+++ b/apps/api/bruno/indexes/views/patch.bru
@@ -13,8 +13,8 @@ patch {
 body:json {
   {
     "name": "Errors last 24h (renamed)",
-    "description": null,
-    "columns": null
+    "columns": null,
+    "timeRange": { "type": "absolute", "start": 1700000000, "end": 1700003600 }
   }
 }
 

--- a/apps/api/drizzle/0020_view_time_range.sql
+++ b/apps/api/drizzle/0020_view_time_range.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "view" ADD COLUMN "time_range" jsonb;

--- a/apps/api/drizzle/meta/0020_snapshot.json
+++ b/apps/api/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1571 @@
+{
+  "id": "dfa5a3ea-6d77-4b25-a6b1-6f7cd0bb38d5",
+  "prevId": "7ebaff1d-11bc-4f12-8457-5a50e7495c79",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_created_by": {
+          "name": "api_key_created_by",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_index_id": {
+          "name": "api_key_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_created_by_user_id_user_id_fk": {
+          "name": "api_key_created_by_user_id_user_id_fk",
+          "tableFrom": "api_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_key_name_unique": {
+          "name": "api_key_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "api_key_token_unique": {
+          "name": "api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.index_settings": {
+      "name": "index_settings",
+      "schema": "",
+      "columns": {
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level_field": {
+          "name": "level_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'severity_text'"
+        },
+        "message_field": {
+          "name": "message_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'body.message'"
+        },
+        "traceback_field": {
+          "name": "traceback_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_fields": {
+          "name": "context_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trace_id_field": {
+          "name": "trace_id_field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trace_id'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.index_stats_snapshot": {
+      "name": "index_stats_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_docs": {
+          "name": "num_docs",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncompressed_bytes": {
+          "name": "uncompressed_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_splits": {
+          "name": "num_splits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_timestamp": {
+          "name": "min_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_timestamp": {
+          "name": "max_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "index_stats_snapshot_index_captured": {
+          "name": "index_stats_snapshot_index_captured",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_token": {
+      "name": "invite_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_token_user": {
+          "name": "invite_token_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_token_expires": {
+          "name": "invite_token_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_token_user_id_user_id_fk": {
+          "name": "invite_token_user_id_user_id_fk",
+          "tableFrom": "invite_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_token_token_unique": {
+          "name": "invite_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_audit": {
+      "name": "search_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_ts": {
+          "name": "start_ts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_ts": {
+          "name": "end_ts",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_hits": {
+          "name": "num_hits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "search_audit_executed_at": {
+          "name": "search_audit_executed_at",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_audit_user_executed": {
+          "name": "search_audit_user_executed",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"search_audit\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_audit_api_key_executed": {
+          "name": "search_audit_api_key_executed",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"search_audit\".\"api_key_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_audit_index_executed": {
+          "name": "search_audit_index_executed",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "search_audit_actor_check": {
+          "name": "search_audit_actor_check",
+          "value": "(\"search_audit\".\"source\" = 'ui'    AND \"search_audit\".\"user_id\" IS NOT NULL AND \"search_audit\".\"api_key_id\" IS NULL)\n\t\t\t OR (\"search_audit\".\"source\" = 'token' AND \"search_audit\".\"api_key_id\" IS NOT NULL AND \"search_audit\".\"user_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.share": {
+      "name": "share",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hit": {
+          "name": "hit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "share_index_id": {
+          "name": "share_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "share_user_id_user_id_fk": {
+          "name": "share_user_id_user_id_fk",
+          "tableFrom": "share",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "share_code_unique": {
+          "name": "share_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_fields": {
+          "name": "display_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_wrap": {
+          "name": "line_wrap",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_mode": {
+          "name": "display_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'table'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_preference_unique": {
+          "name": "user_preference_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_preference_index_id": {
+          "name": "user_preference_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preference_user_id_user_id_fk": {
+          "name": "user_preference_user_id_user_id_fk",
+          "tableFrom": "user_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.view": {
+      "name": "view",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_id": {
+          "name": "index_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "sort_direction": {
+          "name": "sort_direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'desc'"
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "view_user_index_name_unique": {
+          "name": "view_user_index_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "view_index_id": {
+          "name": "view_index_id",
+          "columns": [
+            {
+              "expression": "index_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "view_user_id_user_id_fk": {
+          "name": "view_user_id_user_id_fk",
+          "tableFrom": "view",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "apikey_reference_id_user_id_fk": {
+          "name": "apikey_reference_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active": {
+          "name": "last_active",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_service_account": {
+          "name": "is_service_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1787388021618,
       "tag": "0019_drop_view_description",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1787390335352,
+      "tag": "0020_view_time_range",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1919,6 +1919,65 @@
 						],
 						"type": "string"
 					},
+					"timeRange": {
+						"anyOf": [
+							{
+								"oneOf": [
+									{
+										"properties": {
+											"preset": {
+												"enum": [
+													"5m",
+													"15m",
+													"30m",
+													"1h",
+													"3h",
+													"6h",
+													"24h",
+													"3d",
+													"7d",
+													"30d"
+												],
+												"type": "string"
+											},
+											"type": {
+												"const": "relative"
+											}
+										},
+										"required": [
+											"type",
+											"preset"
+										],
+										"type": "object"
+									},
+									{
+										"properties": {
+											"end": {
+												"minimum": 0,
+												"type": "integer"
+											},
+											"start": {
+												"minimum": 0,
+												"type": "integer"
+											},
+											"type": {
+												"const": "absolute"
+											}
+										},
+										"required": [
+											"type",
+											"start",
+											"end"
+										],
+										"type": "object"
+									}
+								]
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
 					"updatedAt": {
 						"format": "date-time",
 						"type": "string"
@@ -1932,6 +1991,7 @@
 					"filters",
 					"sortDirection",
 					"columns",
+					"timeRange",
 					"createdAt",
 					"updatedAt"
 				],
@@ -16326,6 +16386,65 @@
 											"desc"
 										],
 										"type": "string"
+									},
+									"timeRange": {
+										"anyOf": [
+											{
+												"oneOf": [
+													{
+														"properties": {
+															"preset": {
+																"enum": [
+																	"5m",
+																	"15m",
+																	"30m",
+																	"1h",
+																	"3h",
+																	"6h",
+																	"24h",
+																	"3d",
+																	"7d",
+																	"30d"
+																],
+																"type": "string"
+															},
+															"type": {
+																"const": "relative"
+															}
+														},
+														"required": [
+															"type",
+															"preset"
+														],
+														"type": "object"
+													},
+													{
+														"properties": {
+															"end": {
+																"minimum": 0,
+																"type": "integer"
+															},
+															"start": {
+																"minimum": 0,
+																"type": "integer"
+															},
+															"type": {
+																"const": "absolute"
+															}
+														},
+														"required": [
+															"type",
+															"start",
+															"end"
+														],
+														"type": "object"
+													}
+												]
+											},
+											{
+												"type": "null"
+											}
+										]
 									}
 								},
 								"required": [
@@ -16508,6 +16627,65 @@
 											"desc"
 										],
 										"type": "string"
+									},
+									"timeRange": {
+										"anyOf": [
+											{
+												"oneOf": [
+													{
+														"properties": {
+															"preset": {
+																"enum": [
+																	"5m",
+																	"15m",
+																	"30m",
+																	"1h",
+																	"3h",
+																	"6h",
+																	"24h",
+																	"3d",
+																	"7d",
+																	"30d"
+																],
+																"type": "string"
+															},
+															"type": {
+																"const": "relative"
+															}
+														},
+														"required": [
+															"type",
+															"preset"
+														],
+														"type": "object"
+													},
+													{
+														"properties": {
+															"end": {
+																"minimum": 0,
+																"type": "integer"
+															},
+															"start": {
+																"minimum": 0,
+																"type": "integer"
+															},
+															"type": {
+																"const": "absolute"
+															}
+														},
+														"required": [
+															"type",
+															"start",
+															"end"
+														],
+														"type": "object"
+													}
+												]
+											},
+											{
+												"type": "null"
+											}
+										]
 									}
 								},
 								"required": [],

--- a/apps/api/src/constants.ts
+++ b/apps/api/src/constants.ts
@@ -20,3 +20,18 @@ export const FIELD_VALUES_MAX = 65_000;
 
 /** Fallback `limit` for the field-values endpoint when the caller doesn't pass one. */
 export const FIELD_VALUES_DEFAULT = 100;
+
+// Time ranges
+export const PRESET_OPTIONS = [
+	'5m',
+	'15m',
+	'30m',
+	'1h',
+	'3h',
+	'6h',
+	'24h',
+	'3d',
+	'7d',
+	'30d'
+] as const;
+export type Preset = (typeof PRESET_OPTIONS)[number];

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -14,7 +14,7 @@ import {
 	uniqueIndex
 } from 'drizzle-orm/pg-core';
 
-import type { DisplayMode, Filter } from '../types.js';
+import type { DisplayMode, Filter, TimeRange } from '../types.js';
 
 import { user } from './auth.schema.js';
 
@@ -105,6 +105,7 @@ export const view = pgTable(
 		filters: jsonb('filters').$type<Filter[]>().notNull().default([]),
 		sortDirection: text('sort_direction').$type<'asc' | 'desc'>().notNull().default('desc'),
 		columns: jsonb('columns').$type<string[]>(),
+		timeRange: jsonb('time_range').$type<TimeRange>(),
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 		updatedAt: timestamp('updated_at')
 			.defaultNow()

--- a/apps/api/src/schemas/responses/views.ts
+++ b/apps/api/src/schemas/responses/views.ts
@@ -3,6 +3,7 @@ import * as v from 'valibot';
 import { named } from '../../lib/openapi/describe.js';
 import { isoTimestampString } from '../../utils/valibot.js';
 import { FilterSchema, SortDirectionSchema } from '../filters.js';
+import { TimeRangeSchema } from '../time-range.js';
 
 export const SavedViewResponse = named(
 	'SavedViewResponse',
@@ -14,6 +15,7 @@ export const SavedViewResponse = named(
 		filters: v.array(FilterSchema),
 		sortDirection: SortDirectionSchema,
 		columns: v.nullable(v.array(v.string())),
+		timeRange: v.nullable(TimeRangeSchema),
 		createdAt: isoTimestampString,
 		updatedAt: isoTimestampString
 	})

--- a/apps/api/src/schemas/time-range.ts
+++ b/apps/api/src/schemas/time-range.ts
@@ -1,0 +1,21 @@
+import * as v from 'valibot';
+
+import { PRESET_OPTIONS } from '../constants.js';
+import type { TimeRange } from '../types.js';
+
+const epochSeconds = v.pipe(v.number(), v.integer(), v.minValue(0));
+
+export const TimeRangeSchema: v.GenericSchema<TimeRange> = v.variant('type', [
+	v.object({
+		type: v.literal('relative'),
+		preset: v.picklist(PRESET_OPTIONS)
+	}),
+	v.pipe(
+		v.object({
+			type: v.literal('absolute'),
+			start: epochSeconds,
+			end: epochSeconds
+		}),
+		v.check((r) => r.end > r.start, 'end must be greater than start')
+	)
+]);

--- a/apps/api/src/schemas/views.ts
+++ b/apps/api/src/schemas/views.ts
@@ -1,6 +1,7 @@
 import * as v from 'valibot';
 
 import { FilterSchema, SortDirectionSchema } from './filters.js';
+import { TimeRangeSchema } from './time-range.js';
 import { IndexIdParams } from '../utils/params.js';
 import { positiveInt } from '../utils/valibot.js';
 
@@ -9,7 +10,8 @@ export const createViewSchema = v.object({
 	query: v.string(),
 	filters: v.optional(v.array(FilterSchema)),
 	sortDirection: v.optional(SortDirectionSchema),
-	columns: v.optional(v.nullable(v.array(v.string())))
+	columns: v.optional(v.nullable(v.array(v.string()))),
+	timeRange: v.optional(v.nullable(TimeRangeSchema))
 });
 
 export const patchViewSchema = v.pipe(
@@ -18,7 +20,8 @@ export const patchViewSchema = v.pipe(
 		query: v.optional(v.string()),
 		filters: v.optional(v.array(FilterSchema)),
 		sortDirection: v.optional(SortDirectionSchema),
-		columns: v.optional(v.nullable(v.array(v.string())))
+		columns: v.optional(v.nullable(v.array(v.string()))),
+		timeRange: v.optional(v.nullable(TimeRangeSchema))
 	}),
 	v.check((b) => Object.keys(b).length > 0, 'at least one field is required')
 );

--- a/apps/api/src/services/view.service.ts
+++ b/apps/api/src/services/view.service.ts
@@ -2,7 +2,7 @@ import { and, desc, eq } from 'drizzle-orm';
 
 import type { Db } from '../db/index.js';
 import { view } from '../db/schema.js';
-import type { Filter, SavedView, SortDirection } from '../types.js';
+import type { Filter, SavedView, SortDirection, TimeRange } from '../types.js';
 import { internal, notFound } from '../utils/http-error.js';
 import { withUniqueViolation } from '../utils/db.js';
 
@@ -20,6 +20,7 @@ function toPublic(row: ViewRow): SavedView {
 		filters: row.filters,
 		sortDirection: row.sortDirection,
 		columns: row.columns,
+		timeRange: row.timeRange,
 		createdAt: row.createdAt.toISOString(),
 		updatedAt: row.updatedAt.toISOString()
 	};
@@ -44,6 +45,7 @@ export async function createView(
 		filters?: Filter[];
 		sortDirection?: SortDirection;
 		columns?: string[] | null;
+		timeRange?: TimeRange | null;
 	}
 ): Promise<SavedView> {
 	// Omitted optional fields fall back to the column defaults in db/schema.ts.
@@ -68,6 +70,7 @@ export async function updateOwnedView(
 		filters?: Filter[];
 		sortDirection?: SortDirection;
 		columns?: string[] | null;
+		timeRange?: TimeRange | null;
 	}
 ): Promise<SavedView> {
 	// Callers guarantee at least one field; drizzle's .set() drops undefined keys.

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,4 +1,8 @@
 import type * as v from 'valibot';
+
+import type { Preset } from './constants.js';
+
+export type { Preset };
 import type {
 	DynamicMappingSchema,
 	FieldValueEntrySchema,
@@ -106,6 +110,9 @@ export type Filter = {
 };
 
 export type SortDirection = 'asc' | 'desc';
+
+export type TimeRange =
+	{ type: 'relative'; preset: Preset } | { type: 'absolute'; start: number; end: number };
 
 export type FieldValuesBulkResponse = v.InferOutput<typeof FieldValuesBulkResponseSchema>;
 

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -214,7 +214,8 @@
 		@apply bg-primary absolute inset-y-1.5 left-0 w-0.5 rounded-full opacity-0 transition-opacity duration-150;
 	}
 
-	&[aria-current='page'] > .nav-rail-bar {
+	&[aria-current='page'] > .nav-rail-bar,
+	&[aria-current='true'] > .nav-rail-bar {
 		@apply opacity-100;
 	}
 }

--- a/apps/web/src/lib/api/views.ts
+++ b/apps/web/src/lib/api/views.ts
@@ -1,7 +1,7 @@
 import { client } from '$lib/api/client';
 import { readApiError } from '$lib/api/errors';
 import type { SavedView } from 'api/types';
-import type { Filter, SortDirection } from '$lib/types';
+import type { Filter, SortDirection, TimeRange } from '$lib/types';
 
 export type ViewCreateInput = {
 	name: string;
@@ -9,6 +9,7 @@ export type ViewCreateInput = {
 	filters: Filter[];
 	sortDirection: SortDirection;
 	columns: string[] | null;
+	timeRange: TimeRange | null;
 };
 
 export type ViewPatch = {
@@ -17,6 +18,7 @@ export type ViewPatch = {
 	filters?: Filter[];
 	sortDirection?: SortDirection;
 	columns?: string[] | null;
+	timeRange?: TimeRange | null;
 };
 
 export async function listViews(indexId: string): Promise<SavedView[]> {

--- a/apps/web/src/lib/components/search/ViewsDropdown.svelte
+++ b/apps/web/src/lib/components/search/ViewsDropdown.svelte
@@ -1,14 +1,5 @@
 <script lang="ts">
-	import {
-		ArrowLeft,
-		Check,
-		ChevronDown,
-		Layers,
-		Pencil,
-		Plus,
-		RefreshCw,
-		Trash2
-	} from 'lucide-svelte';
+	import { ArrowLeft, ChevronDown, Layers, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-svelte';
 	import * as v from 'valibot';
 	import { ApiError, issuesToFieldErrors } from '$lib/api/errors';
 	import { listViews, createView, updateView, deleteView } from '$lib/api/views';
@@ -16,12 +7,14 @@
 	import SearchInput from '$lib/components/ui/SearchInput.svelte';
 	import type { SearchStore } from '$lib/stores/search.svelte';
 	import { RequestGuard } from '$lib/stores/request-guard';
+	import { formatTimeRangeLabel } from '$lib/utils/time-range';
 	import { createViewSchema, patchViewSchema } from 'api/schemas';
 	import type { SavedView } from 'api/types';
 
 	let { store }: { store: SearchStore } = $props();
 
 	let items = $state<SavedView[]>([]);
+	let appliedId = $state<number | null>(null);
 	let loading = $state(false);
 	let error = $state<string | null>(null);
 
@@ -40,27 +33,20 @@
 	let panel = $state<Panel>('list');
 	let editing = $state<SavedView | null>(null);
 	let formName = $state('');
+	let saveTime = $state(true);
 	let formError = $state<string | null>(null);
 	let fieldErrors = $state<Record<string, string>>({});
 	let formSubmitting = $state(false);
 
-	function currentSnapshot() {
+	function currentSnapshot(opts: { withTime: boolean; withColumns: boolean }) {
 		return {
 			query: store.query,
 			filters: store.filters,
 			sortDirection: store.sortDirection,
-			columns: [...store.activeFields]
+			// Empty means display preferences haven't resolved yet, not "no columns".
+			columns: opts.withColumns && store.activeFields.length > 0 ? [...store.activeFields] : null,
+			timeRange: opts.withTime ? store.timeRange : null
 		};
-	}
-
-	function isApplied(item: SavedView) {
-		if (item.query !== store.query || item.sortDirection !== store.sortDirection) return false;
-		const current = store.filters;
-		if (item.filters.length !== current.length) return false;
-		return item.filters.every((f, i) => {
-			const g = current[i];
-			return g.field === f.field && g.value === f.value && g.exclude === f.exclude;
-		});
 	}
 
 	const refreshGuard = new RequestGuard();
@@ -89,8 +75,11 @@
 	}
 
 	function applyView(item: SavedView) {
+		appliedId = item.id;
+		// A view saved without a time range leaves the current one alone.
+		const timeRange = item.timeRange ?? store.timeRange;
 		store.navigateQuery(
-			{ query: item.query, filters: item.filters, sortDirection: item.sortDirection },
+			{ query: item.query, filters: item.filters, sortDirection: item.sortDirection, timeRange },
 			{ push: true }
 		);
 		if (item.columns !== null) store.setActiveFields([...item.columns]);
@@ -100,6 +89,7 @@
 	function openNewForm(prefillName = '') {
 		editing = null;
 		formName = prefillName;
+		saveTime = true;
 		formError = null;
 		fieldErrors = {};
 		panel = 'form';
@@ -153,7 +143,7 @@
 				items = items.map((it) => (it.id === row.id ? row : it));
 			};
 		} else {
-			const input = { name, ...currentSnapshot() };
+			const input = { name, ...currentSnapshot({ withTime: saveTime, withColumns: true }) };
 			const parsed = v.safeParse(createViewSchema, input);
 			if (!parsed.success) {
 				fieldErrors = issuesToFieldErrors(parsed.issues);
@@ -162,6 +152,7 @@
 			save = async () => {
 				const row = await createView(indexId, input);
 				items = [row, ...items];
+				appliedId = row.id;
 			};
 		}
 
@@ -194,8 +185,13 @@
 		if (!item) return;
 		const indexId = store.selectedIndex;
 		if (indexId === null) throw new Error('No index selected');
-		const row = await updateView(indexId, item.id, currentSnapshot());
+		const row = await updateView(
+			indexId,
+			item.id,
+			currentSnapshot({ withTime: item.timeRange !== null, withColumns: item.columns !== null })
+		);
 		items = items.map((it) => (it.id === row.id ? row : it));
+		appliedId = row.id;
 		toOverwrite = null;
 	}
 
@@ -211,6 +207,7 @@
 		if (indexId === null) throw new Error('No index selected');
 		await deleteView(indexId, item.id);
 		items = items.filter((it) => it.id !== item.id);
+		if (appliedId === item.id) appliedId = null;
 		toDelete = null;
 	}
 
@@ -237,7 +234,10 @@
 	let lastIndex: string | null | undefined;
 	$effect(() => {
 		const current = store.selectedIndex;
-		if (lastIndex !== undefined && current !== lastIndex) close();
+		if (lastIndex !== undefined && current !== lastIndex) {
+			appliedId = null;
+			close();
+		}
 		lastIndex = current;
 	});
 </script>
@@ -276,7 +276,7 @@
 			</button>
 		</div>
 
-		<div class="max-h-72 min-h-[6rem] flex-1 overflow-y-auto">
+		<div class="max-h-[28rem] min-h-[12rem] flex-1 overflow-y-auto">
 			{#if error && items.length > 0}
 				<p class="text-error border-line border-b px-3 py-2 text-xs">{error}</p>
 			{/if}
@@ -315,20 +315,20 @@
 			{:else}
 				<ul class="p-1">
 					{#each filtered as item (item.id)}
-						{@const applied = isApplied(item)}
+						{@const applied = item.id === appliedId}
 						<li>
-							<div class="group hover:bg-base-200 flex items-center rounded">
+							<div
+								class="group hover:bg-base-200/60 flex items-center rounded"
+								class:bg-base-200={applied}
+							>
 								<button
 									type="button"
-									class="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
+									aria-current={applied ? 'true' : undefined}
+									class="nav-rail flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
 									onclick={() => applyView(item)}
 									title={item.query || 'Empty query'}
 								>
-									<span class="flex w-3.5 shrink-0 justify-center">
-										{#if applied}
-											<Check class="text-primary h-3.5 w-3.5" />
-										{/if}
-									</span>
+									<span class="nav-rail-bar"></span>
 									<span class="truncate text-xs" class:font-medium={applied}>{item.name}</span>
 								</button>
 								<div
@@ -402,6 +402,10 @@
 				<p class="text-base-content/60 text-xs">
 					Saves the current query, filters, sort direction, and columns.
 				</p>
+				<label class="flex items-center gap-1.5 text-xs">
+					<input type="checkbox" class="checkbox checkbox-xs" bind:checked={saveTime} />
+					Save time range ({formatTimeRangeLabel(store.timeRange)})
+				</label>
 			{/if}
 
 			{#if formError}
@@ -441,6 +445,6 @@
 >
 	{#snippet message()}
 		Overwrite <span class="font-semibold">{toOverwrite?.name}</span> with the current search? Its saved
-		query, filters, sort direction, and columns will be replaced.
+		settings will be replaced.
 	{/snippet}
 </ConfirmModal>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,7 +1,6 @@
-import type { Preset } from '$lib/utils/time-range';
-import type { Filter, SortDirection, TraceSpan } from 'api/types';
+import type { Filter, SortDirection, TimeRange, TraceSpan } from 'api/types';
 
-export type { Filter, SortDirection };
+export type { Filter, SortDirection, TimeRange };
 
 /** One crumb in a breadcrumb trail. Ancestors set `href`; the current page omits it. */
 export type BreadcrumbSegment = { label: string; href?: string; mono?: boolean };
@@ -89,9 +88,6 @@ export interface LogFieldValueBucket {
 	value: string;
 	count: number;
 }
-
-export type TimeRange =
-	{ type: 'relative'; preset: Preset } | { type: 'absolute'; start: number; end: number };
 
 export interface ParsedQuery {
 	index: string | null;

--- a/apps/web/src/lib/utils/query-params.ts
+++ b/apps/web/src/lib/utils/query-params.ts
@@ -77,8 +77,10 @@ export function deserialize(params: URLSearchParams): ParsedQuery {
 	const fromNum = from !== null && from !== '' ? Number(from) : NaN;
 	const toNum = to !== null && to !== '' ? Number(to) : NaN;
 
+	// Floored, not rejected: the API's TimeRangeSchema requires integer epoch seconds, but a
+	// fractional bookmark should still search its intended window.
 	if (Number.isFinite(fromNum) && Number.isFinite(toNum) && fromNum >= 0 && fromNum < toNum) {
-		timeRange = { type: 'absolute', start: fromNum, end: toNum };
+		timeRange = { type: 'absolute', start: Math.floor(fromNum), end: Math.ceil(toNum) };
 	} else if (from !== null && isPreset(from)) {
 		timeRange = { type: 'relative', preset: from };
 	} else {

--- a/apps/web/src/lib/utils/time-range.ts
+++ b/apps/web/src/lib/utils/time-range.ts
@@ -1,20 +1,11 @@
 import { format, fromUnixTime, getUnixTime, isSameDay, isSameYear } from 'date-fns';
 
 import type { TimeRange } from '$lib/types';
+import { PRESET_OPTIONS } from 'api/constants';
+import type { Preset } from 'api/types';
 
-export const PRESET_OPTIONS = [
-	'5m',
-	'15m',
-	'30m',
-	'1h',
-	'3h',
-	'6h',
-	'24h',
-	'3d',
-	'7d',
-	'30d'
-] as const;
-export type Preset = (typeof PRESET_OPTIONS)[number];
+export { PRESET_OPTIONS };
+export type { Preset };
 
 const PRESET_SECONDS: Record<Preset, number> = {
 	'5m': 5 * 60,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saved views can now store and restore relative or absolute time ranges.
  * Added supported presets from 5 minutes through 30 days.
  * Added an option to include or exclude the current time range when saving a view.
  * Improved indicators for the currently applied view and expanded the views list.

* **Bug Fixes**
  * Improved handling of fractional time-range timestamps for consistent query boundaries.
  * Active navigation indicators now display correctly across supported states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->