### PR TITLE
Add UNKNOWN to LEVELS and refactor histogram

### DIFF
--- a/apps/api/src/schemas/responses/indexes.ts
+++ b/apps/api/src/schemas/responses/indexes.ts
@@ -158,7 +158,8 @@ export const HistogramBucketSchema = named(
 		key: v.number(),
 		keyAsString: v.string(),
 		docCount: v.number(),
-		levels: v.record(v.string(), v.number())
+		levels: v.record(v.string(), v.number()),
+		omittedCount: v.number()
 	})
 );
 

--- a/apps/api/src/services/log.service.ts
+++ b/apps/api/src/services/log.service.ts
@@ -95,7 +95,8 @@ export async function histogramLogs(
 				key: Number(b.key),
 				keyAsString: b.key_as_string ?? String(b.key),
 				docCount: b.doc_count,
-				levels
+				levels,
+				omittedCount: levelsAgg?.sum_other_doc_count ?? 0
 			};
 		})
 	};

--- a/apps/web/src/lib/api/histogram.ts
+++ b/apps/web/src/lib/api/histogram.ts
@@ -1,4 +1,5 @@
 import { client } from '$lib/api/client';
+import { UNKNOWN_LEVEL } from '$lib/constants/level-colors';
 import { readApiError } from '$lib/api/errors';
 import type { HistogramBucket, HistogramInput, HistogramResult } from '$lib/types';
 import {
@@ -34,7 +35,19 @@ export async function fetchHistogram(
 	const bucketMap = new Map<number, { levels: Record<string, number>; count: number }>();
 	let totalDocCount = 0;
 	for (const b of json.buckets) {
-		bucketMap.set(Math.floor(b.key / 1000), { levels: b.levels, count: b.docCount });
+		// Docs whose level field is absent or blank never reach the terms agg, but the
+		// bucket total still counts them; the remainder is UNKNOWN.
+		const levels: Record<string, number> = {};
+		let known = 0;
+		for (const [name, count] of Object.entries(b.levels)) {
+			if (name === '') continue;
+			levels[name] = count;
+			known += count;
+		}
+		const unknown = b.docCount - known;
+		if (unknown > 0) levels[UNKNOWN_LEVEL] = (levels[UNKNOWN_LEVEL] ?? 0) + unknown;
+
+		bucketMap.set(Math.floor(b.key / 1000), { levels, count: b.docCount });
 		totalDocCount += b.docCount;
 	}
 

--- a/apps/web/src/lib/api/histogram.ts
+++ b/apps/web/src/lib/api/histogram.ts
@@ -36,7 +36,6 @@ export async function fetchHistogram(
 	let totalDocCount = 0;
 	for (const b of json.buckets) {
 		// Docs whose level field is absent or blank never reach the terms agg, but the
-		// bucket total still counts them; the remainder is UNKNOWN.
 		const levels: Record<string, number> = {};
 		let known = 0;
 		for (const [name, count] of Object.entries(b.levels)) {
@@ -44,7 +43,7 @@ export async function fetchHistogram(
 			levels[name] = count;
 			known += count;
 		}
-		const unknown = b.docCount - known;
+		const unknown = b.docCount - known - b.omittedCount;
 		if (unknown > 0) levels[UNKNOWN_LEVEL] = (levels[UNKNOWN_LEVEL] ?? 0) + unknown;
 
 		bucketMap.set(Math.floor(b.key / 1000), { levels, count: b.docCount });

--- a/apps/web/src/lib/components/log/LogFrequencyChart.svelte
+++ b/apps/web/src/lib/components/log/LogFrequencyChart.svelte
@@ -8,7 +8,7 @@
 	import { levelColor } from '$lib/constants/level-colors';
 	import type { HistogramBucket } from '$lib/types';
 	import { baseContentAt } from '$lib/utils/chart-colors';
-	import { formatInterval } from '$lib/utils/histogram';
+	import { formatInterval, UNKNOWN_LEVEL, unknownInBucket } from '$lib/utils/histogram';
 	import { sortBySeverity } from '$lib/utils/severity';
 	import { formatChartDate, formatChartTime, formatChartTooltip } from '$lib/utils/time';
 
@@ -30,14 +30,24 @@
 		return formatInterval(buckets[1].timestamp - buckets[0].timestamp);
 	});
 
+	const upperBuckets = $derived.by<Record<string, number>[]>(() =>
+		buckets.map((b) => {
+			const out: Record<string, number> = {};
+			for (const k of Object.keys(b.levels)) {
+				if (k !== '') out[k.toUpperCase()] = b.levels[k];
+			}
+			const unknown = unknownInBucket(b);
+			if (unknown > 0) out[UNKNOWN_LEVEL] = (out[UNKNOWN_LEVEL] ?? 0) + unknown;
+			return out;
+		})
+	);
+
 	const levels = $derived.by<string[]>(() => {
 		const seen = new Set<string>();
-		for (const b of buckets) {
-			for (const k of Object.keys(b.levels)) {
-				seen.add(k.toUpperCase());
-			}
+		for (const u of upperBuckets) {
+			for (const k of Object.keys(u)) seen.add(k);
 		}
-		if (seen.size === 0 && buckets.length > 0) return ['UNKNOWN'];
+		if (seen.size === 0 && buckets.length > 0) return [UNKNOWN_LEVEL];
 		return sortBySeverity([...seen]);
 	});
 
@@ -51,18 +61,7 @@
 		if (buckets.length === 0) return null;
 
 		const timestamps: number[] = buckets.map((b) => b.timestamp);
-
-		const upperBuckets: Record<string, number>[] = buckets.map((b) => {
-			const out: Record<string, number> = {};
-			for (const k of Object.keys(b.levels)) out[k.toUpperCase()] = b.levels[k];
-			return out;
-		});
-
-		const isSyntheticUnknown = levels.length === 1 && levels[0] === 'UNKNOWN';
-
-		const rawSeries: number[][] = isSyntheticUnknown
-			? [buckets.map((b) => b.count)]
-			: levels.map((level) => upperBuckets.map((u) => u[level] ?? 0));
+		const rawSeries: number[][] = levels.map((level) => upperBuckets.map((u) => u[level] ?? 0));
 
 		const stackedSeries: number[][] = [];
 		for (let i = 0; i < rawSeries.length; i++) {

--- a/apps/web/src/lib/components/log/LogFrequencyChart.svelte
+++ b/apps/web/src/lib/components/log/LogFrequencyChart.svelte
@@ -5,10 +5,10 @@
 	import { slide } from 'svelte/transition';
 
 	import UplotChart from '$lib/components/ui/uplot/UplotChart.svelte';
-	import { levelColor } from '$lib/constants/level-colors';
+	import { levelColor, UNKNOWN_LEVEL } from '$lib/constants/level-colors';
 	import type { HistogramBucket } from '$lib/types';
 	import { baseContentAt } from '$lib/utils/chart-colors';
-	import { formatInterval, UNKNOWN_LEVEL, unknownInBucket } from '$lib/utils/histogram';
+	import { formatInterval } from '$lib/utils/histogram';
 	import { sortBySeverity } from '$lib/utils/severity';
 	import { formatChartDate, formatChartTime, formatChartTooltip } from '$lib/utils/time';
 
@@ -30,22 +30,12 @@
 		return formatInterval(buckets[1].timestamp - buckets[0].timestamp);
 	});
 
-	const upperBuckets = $derived.by<Record<string, number>[]>(() =>
-		buckets.map((b) => {
-			const out: Record<string, number> = {};
-			for (const k of Object.keys(b.levels)) {
-				if (k !== '') out[k.toUpperCase()] = b.levels[k];
-			}
-			const unknown = unknownInBucket(b);
-			if (unknown > 0) out[UNKNOWN_LEVEL] = (out[UNKNOWN_LEVEL] ?? 0) + unknown;
-			return out;
-		})
-	);
-
 	const levels = $derived.by<string[]>(() => {
 		const seen = new Set<string>();
-		for (const u of upperBuckets) {
-			for (const k of Object.keys(u)) seen.add(k);
+		for (const b of buckets) {
+			for (const k of Object.keys(b.levels)) {
+				seen.add(k.toUpperCase());
+			}
 		}
 		if (seen.size === 0 && buckets.length > 0) return [UNKNOWN_LEVEL];
 		return sortBySeverity([...seen]);
@@ -61,6 +51,13 @@
 		if (buckets.length === 0) return null;
 
 		const timestamps: number[] = buckets.map((b) => b.timestamp);
+
+		const upperBuckets: Record<string, number>[] = buckets.map((b) => {
+			const out: Record<string, number> = {};
+			for (const k of Object.keys(b.levels)) out[k.toUpperCase()] = b.levels[k];
+			return out;
+		});
+
 		const rawSeries: number[][] = levels.map((level) => upperBuckets.map((u) => u[level] ?? 0));
 
 		const stackedSeries: number[][] = [];

--- a/apps/web/src/lib/components/sidebar/FieldPanel.svelte
+++ b/apps/web/src/lib/components/sidebar/FieldPanel.svelte
@@ -3,6 +3,7 @@
 	import type { LevelBucket, LogField, LogFieldValueBucket } from '$lib/types';
 	import { isOtelAttr, isOtelResourceAttr, serializeTimeRange } from '$lib/utils/fields';
 	import { sortBySeverity } from '$lib/utils/severity';
+	import { UNKNOWN_LEVEL } from '$lib/utils/histogram';
 	import { levelColor } from '$lib/constants/level-colors';
 	import type { SearchStore } from '$lib/stores/search.svelte';
 	import { fetchFieldValuesBulk } from '$lib/api/field-values';
@@ -266,7 +267,7 @@
 										class="flex w-full cursor-pointer items-center gap-2 rounded px-1.5 py-0.5 text-left font-mono text-xs transition-colors duration-150 disabled:cursor-not-allowed"
 										role="checkbox"
 										aria-checked={isActive}
-										disabled={levelField === null}
+										disabled={levelField === null || level.name === UNKNOWN_LEVEL}
 										onclick={() => store.toggleLevelFilter(level.name)}
 									>
 										{#if showFull}

--- a/apps/web/src/lib/components/sidebar/FieldPanel.svelte
+++ b/apps/web/src/lib/components/sidebar/FieldPanel.svelte
@@ -3,8 +3,7 @@
 	import type { LevelBucket, LogField, LogFieldValueBucket } from '$lib/types';
 	import { isOtelAttr, isOtelResourceAttr, serializeTimeRange } from '$lib/utils/fields';
 	import { sortBySeverity } from '$lib/utils/severity';
-	import { UNKNOWN_LEVEL } from '$lib/utils/histogram';
-	import { levelColor } from '$lib/constants/level-colors';
+	import { levelColor, UNKNOWN_LEVEL } from '$lib/constants/level-colors';
 	import type { SearchStore } from '$lib/stores/search.svelte';
 	import { fetchFieldValuesBulk } from '$lib/api/field-values';
 	import { filterKey } from '$lib/utils/query-params';

--- a/apps/web/src/lib/constants/level-colors.ts
+++ b/apps/web/src/lib/constants/level-colors.ts
@@ -17,6 +17,9 @@ const LEVEL_COLORS: Record<string, string> = {
 	unknown: '#8B8D98'
 };
 
+/** Synthetic level for docs whose level field is absent or blank. */
+export const UNKNOWN_LEVEL = 'UNKNOWN';
+
 export function levelColor(name: string): string {
 	return LEVEL_COLORS[name.toLowerCase()] ?? LEVEL_COLORS.unknown;
 }

--- a/apps/web/src/lib/stores/search.svelte.ts
+++ b/apps/web/src/lib/stores/search.svelte.ts
@@ -22,6 +22,7 @@ import { buildQueryUrl } from '$lib/utils/query-params';
 import { normalizeHit } from '$lib/utils/normalize-hit';
 import { readLastIndex, writeLastIndex, clearLastIndex } from '$lib/utils/last-index';
 import { resolveWindow } from '$lib/utils/time-range';
+import { UNKNOWN_LEVEL, unknownInBucket } from '$lib/utils/histogram';
 import { displayNameFor, extractJsonSubFields, serializeTimeRange } from '$lib/utils/fields';
 import { RequestGuard } from '$lib/stores/request-guard';
 import { isAbortError } from '$lib/api/errors';
@@ -249,7 +250,8 @@ export class SearchStore {
 			return;
 		}
 
-		const known = this.#levelsRoster.map((l) => l.name);
+		// UNKNOWN is display-only, so it never counts toward "every level is selected".
+		const known = this.#levelsRoster.map((l) => l.name).filter((n) => n !== UNKNOWN_LEVEL);
 		if (known.length >= 2 && this.#wouldSelectAllLevels(known, levelField, value)) {
 			this.#clearLevelFilters(levelField);
 			return;
@@ -683,11 +685,15 @@ export class SearchStore {
 
 	#computeLevelTotals(buckets: HistogramBucket[]): LevelBucket[] {
 		const totals: Record<string, number> = {};
+		let unknown = 0;
 		for (const b of buckets) {
 			for (const [name, count] of Object.entries(b.levels)) {
+				if (name === '') continue;
 				totals[name] = (totals[name] ?? 0) + count;
 			}
+			unknown += unknownInBucket(b);
 		}
+		if (unknown > 0) totals[UNKNOWN_LEVEL] = (totals[UNKNOWN_LEVEL] ?? 0) + unknown;
 		return Object.entries(totals).map(([name, count]) => ({ name, count }));
 	}
 

--- a/apps/web/src/lib/stores/search.svelte.ts
+++ b/apps/web/src/lib/stores/search.svelte.ts
@@ -22,7 +22,7 @@ import { buildQueryUrl } from '$lib/utils/query-params';
 import { normalizeHit } from '$lib/utils/normalize-hit';
 import { readLastIndex, writeLastIndex, clearLastIndex } from '$lib/utils/last-index';
 import { resolveWindow } from '$lib/utils/time-range';
-import { UNKNOWN_LEVEL, unknownInBucket } from '$lib/utils/histogram';
+import { UNKNOWN_LEVEL } from '$lib/constants/level-colors';
 import { displayNameFor, extractJsonSubFields, serializeTimeRange } from '$lib/utils/fields';
 import { RequestGuard } from '$lib/stores/request-guard';
 import { isAbortError } from '$lib/api/errors';
@@ -685,15 +685,11 @@ export class SearchStore {
 
 	#computeLevelTotals(buckets: HistogramBucket[]): LevelBucket[] {
 		const totals: Record<string, number> = {};
-		let unknown = 0;
 		for (const b of buckets) {
 			for (const [name, count] of Object.entries(b.levels)) {
-				if (name === '') continue;
 				totals[name] = (totals[name] ?? 0) + count;
 			}
-			unknown += unknownInBucket(b);
 		}
-		if (unknown > 0) totals[UNKNOWN_LEVEL] = (totals[UNKNOWN_LEVEL] ?? 0) + unknown;
 		return Object.entries(totals).map(([name, count]) => ({ name, count }));
 	}
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -50,7 +50,8 @@ export interface LogHit {
 export interface HistogramBucket {
 	/** Seconds since epoch at the start of the bucket. */
 	timestamp: number;
-	/** Per-level doc counts within this bucket, keyed by raw level value. */
+	/** Per-level doc counts within this bucket, keyed by raw level value. Docs with no
+	 *  level are folded into an `UNKNOWN` key. */
 	levels: Record<string, number>;
 	/** Total hit count for the bucket (sum across levels). */
 	count: number;

--- a/apps/web/src/lib/utils/histogram.ts
+++ b/apps/web/src/lib/utils/histogram.ts
@@ -68,15 +68,3 @@ export function padHistogramBuckets(
 
 	return buckets;
 }
-
-export const UNKNOWN_LEVEL = 'UNKNOWN';
-
-/** Docs with an absent or empty level field never appear in the terms agg, but the
- *  bucket total still counts them. Empty-string keys fold in as unknown too. */
-export function unknownInBucket(b: HistogramBucket): number {
-	let known = 0;
-	for (const [name, count] of Object.entries(b.levels)) {
-		if (name !== '') known += count;
-	}
-	return Math.max(0, b.count - known);
-}

--- a/apps/web/src/lib/utils/histogram.ts
+++ b/apps/web/src/lib/utils/histogram.ts
@@ -68,3 +68,15 @@ export function padHistogramBuckets(
 
 	return buckets;
 }
+
+export const UNKNOWN_LEVEL = 'UNKNOWN';
+
+/** Docs with an absent or empty level field never appear in the terms agg, but the
+ *  bucket total still counts them. Empty-string keys fold in as unknown too. */
+export function unknownInBucket(b: HistogramBucket): number {
+	let known = 0;
+	for (const [name, count] of Object.entries(b.levels)) {
+		if (name !== '') known += count;
+	}
+	return Math.max(0, b.count - known);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved histogram and log frequency charts to accurately represent documents with missing or blank level information.
  * Grouped documents without a level under a consistent “UNKNOWN” category.
  * Prevented the unknown category from affecting known-level filter selections.
  * Disabled filtering controls for the display-only unknown category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->