### PR TITLE
Fix duplicate field-value buckets in log filters

### DIFF
--- a/apps/api/src/services/log.service.ts
+++ b/apps/api/src/services/log.service.ts
@@ -23,10 +23,13 @@ function isTruncated(agg: BucketAggregationResult | undefined): boolean {
 
 /** Maps terms-aggregation buckets to field-value entries, dropping empty-string keys. */
 function bucketsToEntries(agg: BucketAggregationResult | undefined): FieldValueEntry[] {
-	return asBuckets(agg).flatMap((b) => {
+	const totals = new Map<string, number>();
+	for (const b of asBuckets(agg)) {
 		const value = String(b.key);
-		return value === '' ? [] : [{ value, count: b.doc_count }];
-	});
+		if (value === '') continue;
+		totals.set(value, (totals.get(value) ?? 0) + b.doc_count);
+	}
+	return [...totals].map(([value, count]) => ({ value, count }));
 }
 
 type HistogramParams = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregated results now combine duplicate keys and sum their document counts, producing more accurate totals.
  * Empty-string keys continue to be excluded from results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->